### PR TITLE
EF-1288 Fix incorrect type for currentModule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "processhub-sdk",
-  "version": "8.28.0",
+  "version": "8.29.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "8.28.0",
+  "version": "8.29.0-0",
   "author": {
     "name": "ProcessHub",
     "email": "info@processhub.com",

--- a/src/phroxapi/legacyapi.ts
+++ b/src/phroxapi/legacyapi.ts
@@ -3,7 +3,6 @@ import { IRoxFile, IRoxFolder, IModuleSelection } from ".";
 import { Instance } from "..";
 import { IFieldContentMap } from "../data";
 import { ITaskExtensions } from "../process/processinterfaces";
-import { ModuleId } from "../modules";
 
 export const RequestRoutes = {
   GetRootFolder: "/api/phroxapi/getrootfolder",
@@ -120,7 +119,7 @@ export interface IEcReleaseFileLockReply {
 }
 
 export interface IGetModuleSettingsReply extends IBaseReply {
-  currentModule: ModuleId;
+  currentModule: string;
   refreshinterval: number;
   class?: string;
   mainItems: IModuleSelection[];


### PR DESCRIPTION
as `currentModule` is returned as string from API.