### PR TITLE
Use DevBot Token to create PR to make subsequent builds happen

### DIFF
--- a/.github/workflows/trigger_release_creation.yml
+++ b/.github/workflows/trigger_release_creation.yml
@@ -31,10 +31,11 @@ jobs:
           npm run release-make-next-rc-final
           NEWVERSION=$(echo "console.log(require('./package.json').version);" | node)
           echo "::set-output name=newversion::$(echo $NEWVERSION)"
-      - name: Create Branch
+      - name: Create Branch and Push Branch and Tag
         run: |
           git checkout -b release-v${{ steps.version-upgrade.outputs.newversion }}
           git push -u origin release-v${{ steps.version-upgrade.outputs.newversion }}
+          git push origin v${{ steps.version-upgrade.outputs.newversion }}
       - name: Create PR for new Version
         uses: repo-sync/pull-request@v2
         with:
@@ -42,6 +43,6 @@ jobs:
           destination_branch: 'master'
           pr_title: 'Release v${{ steps.version-upgrade.outputs.newversion }}'
           pr_body: Updates version to v${{ steps.version-upgrade.outputs.newversion }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DEVBOT_GH_TOKEN }}
           pr_assignee: '${{ github.actor }}'
           pr_draft: false


### PR DESCRIPTION
* As Github blocks subsequent workflow runs from a workflow executed with the GITHUB_TOKEN to avoid recursive runs