### PR TITLE
EF-1778 Add types for TreeView field, Disable @typescript-eslint/indent rule as it collides with prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "prettier"
   ],
   "rules": {
     "linebreak-style": ["error", "unix"],
@@ -57,7 +58,6 @@
         "varsIgnorePattern": ""
       }
     ],
-    "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/prefer-namespace-keyword": "error",
     "semi": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "processhub-sdk",
-  "version": "9.16.0-3",
+  "version": "9.16.0-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "9.16.0-3",
+  "version": "9.16.0-4",
   "author": {
     "name": "ProcessHub",
     "email": "info@processhub.com",

--- a/src/data/datainterfaces.test.ts
+++ b/src/data/datainterfaces.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { FieldTypeOptions, isFieldValue } from "./datainterfaces";
+import { FieldTypeOptions, isFieldValue, ITreeViewFieldValue, TreeViewFieldValueSchema } from "./datainterfaces";
 
 describe("sdk", function () {
   describe("data", function () {
@@ -29,6 +29,30 @@ describe("sdk", function () {
 
           // Field with date value
           expect(isFieldValue({ type: FieldTypeOptions[0], value: new Date() })).to.be.true;
+        });
+
+        it("accepts TreeView FieldValues", function () {
+          // Field with undefined value
+          expect(TreeViewFieldValueSchema.required().validate(undefined).error).to.not.be.undefined;
+
+          const treeViewEntry: ITreeViewFieldValue = {
+            entries: [
+              {
+                id: "123",
+                name: "Test",
+                checked: false,
+                subItems: [],
+              },
+            ],
+          };
+
+          expect(TreeViewFieldValueSchema.required().validate(treeViewEntry).error).to.be.undefined;
+
+          const treeViewEntryEmpty: ITreeViewFieldValue = {
+            entries: [],
+          };
+
+          expect(TreeViewFieldValueSchema.required().validate(treeViewEntryEmpty).error).to.be.undefined;
         });
       });
     });

--- a/src/data/datainterfaces.ts
+++ b/src/data/datainterfaces.ts
@@ -25,6 +25,7 @@ export const FieldTypeOptions = [
   "ProcessHubDate",
   "ProcessHubDropdown",
   "ProcessHubChecklist",
+  "ProcessHubTreeView",
   "ProcessHubRadioButton",
   "ProcessHubDecision",
   "ProcessHubRoxFile",
@@ -312,7 +313,16 @@ export const ISVGDropdownOptionSchema = Joi.object(ISVGDropdownOptionObject);
 
 export interface IFieldConfigDefault extends IFieldConfig {
   validationExpression?: string;
-  defaultValue?: string | Date | ChecklistFieldValue | IRadioButtonGroupFieldValue | ISpreadSheetFieldValue | IRoxFileLinkValue | ITasksFieldValue | ISVGDropdownOption;
+  defaultValue?:
+    | string
+    | Date
+    | ChecklistFieldValue
+    | IRadioButtonGroupFieldValue
+    | ISpreadSheetFieldValue
+    | IRoxFileLinkValue
+    | ITasksFieldValue
+    | ISVGDropdownOption
+    | ITreeViewFieldValue;
 }
 
 const IFieldConfigDefaultObject: IFieldConfigDefault = {
@@ -346,6 +356,63 @@ const IChecklistFieldConfigObject: IChecklistFieldConfig = {
 };
 
 export const IChecklistFieldConfigSchema = Joi.object(IChecklistFieldConfigObject);
+
+// TreeView
+//
+
+/**
+ * Represents one TreeView Entry
+ */
+export interface ITreeViewEntry {
+  id: string;
+  name: string;
+  checked: boolean;
+  subItems: ITreeViewEntry[];
+}
+
+const TreeViewEntryObject: ITreeViewEntry = {
+  id: Joi.string() as unknown as string,
+  name: Joi.string().allow("") as unknown as string,
+  checked: Joi.boolean() as unknown as boolean,
+  subItems: Joi.array().items(Joi.object(ITasksFieldTaskObject)).required() as unknown as ITreeViewEntry[],
+};
+
+export const TreeViewEntrySchema = Joi.object(TreeViewEntryObject);
+
+/**
+ * TreeView Config Object
+ */
+export interface ITreeViewFieldConfig extends IFieldConfigDefault {
+  entries: ITreeViewEntry[];
+  oneEntryMustBeChecked: boolean;
+}
+
+const TreeViewFieldConfigObject: ITreeViewFieldConfig = {
+  entries: Joi.array().items(Joi.object(TreeViewEntryObject)).required() as unknown as ITreeViewEntry[],
+  oneEntryMustBeChecked: Joi.boolean().required() as unknown as boolean,
+  // Extends IFieldConfigDefault
+  ...IFieldConfigDefaultObject,
+};
+
+export const TreeViewFieldConfigSchema = Joi.object(TreeViewFieldConfigObject);
+
+// ---------------------------
+
+/**
+ * Represents whole TreeView data (also in DB)
+ */
+export interface ITreeViewFieldValue {
+  entries: ITreeViewEntry[];
+}
+
+const TreeViewFieldValueObject: ITreeViewFieldValue = {
+  entries: Joi.array().items(Joi.object(TreeViewEntryObject)).required() as unknown as ITreeViewEntry[],
+};
+
+export const TreeViewFieldValueSchema = Joi.object(TreeViewFieldValueObject);
+
+// End TreeView
+//
 
 export type IDateFieldConfig = IFieldConfigDefault;
 
@@ -557,7 +624,8 @@ export type FieldValueType =
   | IRoxFileLinkValue // RoxFileLink
   | IRiskAssessmentTargetValue // RiskAssessmentTarget
   | ISVGDropdownOption // SVGDropdown
-  | ITasksFieldValue; // TasksField;
+  | ITasksFieldValue // TasksField
+  | ITreeViewFieldValue; // TreeViewField
 
 const FieldValueTypeSchema = [
   Joi.allow(null),
@@ -577,6 +645,7 @@ const FieldValueTypeSchema = [
   IRiskAssessmentTargetValueSchema,
   ISVGDropdownOptionSchema,
   ITasksFieldValueSchema,
+  TreeViewFieldValueSchema,
 ];
 
 export interface IFieldValue {


### PR DESCRIPTION
* Add types for TreeView field
* Disable @typescript-eslint/indent rule as it collides with prettier

Issue: EF-1778