### PR TITLE
Remove ViewArchive and ViewTodos access rights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "processhub-sdk",
-  "version": "9.21.0-5",
+  "version": "9.21.0-6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "9.21.0-5",
+  "version": "9.21.0-6",
   "author": {
     "name": "ProcessHub",
     "email": "info@processhub.com",

--- a/src/process/processinterfaces.ts
+++ b/src/process/processinterfaces.ts
@@ -127,12 +127,9 @@ export interface IProcessSettings {
 
 export enum ProcessViewAccess {
   // DO NOT CHANGE NUMBERS - used in database
-  EverybodySeesAll = 10, // All todos/instances are public  NOT YET IMPLEMENTED
   // Not implemented because Dashboard uses user.extras.todos, which is not available for anonymous guests
   WorkspaceMembersSeeAll = 20, // Team members see all todos/instances
-  ParticipantsSeeAll = 30, // Process participants see all todos/instances
   ParticipantsSeeTheirs = 40, // Process participants see their own todos/instances
-  OnlyProcessOwners = 50, // Only process managers can see todos/instances
 }
 
 export enum ProcessExtras {

--- a/src/process/processrights.ts
+++ b/src/process/processrights.ts
@@ -17,8 +17,6 @@ export enum ProcessAccessRights {
   ManageProcess = 1 << 1,
   StartProcess = 1 << 2,
   ViewProcess = 1 << 3,
-  ViewArchive = 1 << 4, // Access to archive tab (available for all workspace members)
-  ViewTodos = 1 << 6, // Access to dashboard tab (available for all members and guests)
   ViewAllTodos = 1 << 7, // User can see all instances, not only instance with own role
   StartProcessByMail = 1 << 8, // User can start this process by mail
   StartProcessByTimer = 1 << 9, // User can start this process by timer
@@ -378,7 +376,7 @@ export function canStartProcessByTimer(process: IProcessDetails | undefined, use
 export function canViewTodos(process: IProcessDetails): boolean {
   if (process == null || process.userRights == null) return false;
 
-  return canViewAllTodos(process) || (process.userRights & ProcessAccessRights.ViewTodos) !== 0;
+  return canViewAllTodos(process) || process.userRights !== 0;
 }
 export function canViewAllTodos(process: IProcessDetails): boolean {
   if (process == null || process.userRights == null) return false;
@@ -389,7 +387,7 @@ export function canViewAllTodos(process: IProcessDetails): boolean {
 export function canViewArchive(process: IProcessDetails): boolean {
   if (process == null || process.userRights == null) return false;
 
-  return (process.userRights & ProcessAccessRights.ViewArchive) !== 0;
+  return process.userRights !== 0;
 }
 
 export function canDeleteProcess(process: IProcessDetails, user: IUserDetails): boolean {


### PR DESCRIPTION
* Access rights are no longer required as everybody is allowed to view the archive (=instance list) and todos as access permissions for individual instances are checked anyway

Issue: EF-1923