### PR TITLE
Replace renderValueToMarkdown by renderValueForComment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "processhub-sdk",
-  "version": "9.33.0-12",
+  "version": "9.33.0-13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "9.33.0-12",
+  "version": "9.33.0-13",
   "author": {
     "name": "ProcessHub",
     "email": "info@processhub.com",

--- a/src/data/ifieldtype.ts
+++ b/src/data/ifieldtype.ts
@@ -51,7 +51,16 @@ export interface IFieldType<ConfigType extends IFieldConfig, ValueType extends F
     config?: IFieldConfig,
     showDirect?: boolean,
   ): JSX.Element | undefined;
-  renderValueToMarkdown(value: {} | undefined | null, instance: IInstanceDetails, process: IProcessDetails, user: IUserDetails, config?: IFieldConfig): string | undefined;
+  /**
+   * Render value for comment section (audittrail)
+   */
+  renderValueForComment(
+    value: {} | undefined | null,
+    instance: IInstanceDetails,
+    process: IProcessDetails,
+    user: IUserDetails,
+    config?: IFieldConfig,
+  ): JSX.Element | undefined;
   renderValueToString(value: {} | undefined, instance: IInstanceDetails, process: IProcessDetails, user: IUserDetails, config?: IFieldConfig): string | undefined;
   getGridDataObject(
     field: IFieldValue,


### PR DESCRIPTION
* Remove renderValueToMarkdown as it is no longer used
* renderValueForComment returns JSX.Element instead of string

Issue: EF-1249, EF-2478