### PR TITLE
Change type of parentProcessDetails, childProcessDetails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "processhub-sdk",
-  "version": "9.34.0-3",
+  "version": "9.34.0-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "9.34.0-3",
+  "version": "9.34.0-4",
   "author": {
     "name": "ProcessHub",
     "email": "info@processhub.com",

--- a/src/process/processinterfaces.ts
+++ b/src/process/processinterfaces.ts
@@ -62,6 +62,16 @@ export interface IServiceActionField {
   onload: ServiceActionFieldOnloadFunction | string;
 }
 
+/**
+ * Base information for subprocesses / parent processes
+ */
+export interface ISubParentBaseProcessInformation {
+  processId: string;
+  workspaceId: string;
+  displayName: string;
+  urlName: string;
+}
+
 export interface IProcessDetails {
   processId: string;
   workspaceId: string;
@@ -106,8 +116,8 @@ export interface IProcessDetails {
     svgString?: string; // Only used to save preview to server or if requested in extras
     settings?: IProcessSettings;
     auditTrail?: IAuditTrailEntry[];
-    parentProcessDetails?: IProcessDetails[];
-    childProcessDetails?: IProcessDetails[];
+    parentProcessDetails?: ISubParentBaseProcessInformation[];
+    childProcessDetails?: ISubParentBaseProcessInformation[];
   };
 }
 


### PR DESCRIPTION
Change type of parentProcessDetails, childProcessDetails to only contain base information about process

* To be able to only return base information of a sub/parent process

Issue: EF-2238