### PR TITLE
Transfer timeframe selection as milliseconds

### DIFF
--- a/src/instance/legacyapi.ts
+++ b/src/instance/legacyapi.ts
@@ -186,7 +186,7 @@ const IGenerateReportRequestTypeOptions = ["docx", "pdf"] as const;
 export type IGenerateReportRequestType = typeof IGenerateReportRequestTypeOptions[number];
 
 export interface IGenerateReportRequest extends IBaseRequest {
-  statisticsChart: IStatisticsChartDetails;
+  statisticsChart?: IStatisticsChartDetails;
   instanceIds: string[];
   draftId: string;
   type: IGenerateReportRequestType;

--- a/src/process/legacyapi.ts
+++ b/src/process/legacyapi.ts
@@ -218,9 +218,18 @@ export interface IDeleteFileRequest extends IBaseRequest {
 }
 
 export interface IGetProcessStatisticsRequest extends IBaseRequest {
+  /**
+   * Request statistics for given processId
+   */
   processId: string;
-  fromDate?: Date;
-  tillDate?: Date;
+  /**
+   * Selected timeframe start date in UTC milliseconds
+   */
+  fromDateUTCMillis?: number;
+  /**
+   * Selected timeframe end date in UTC milliseconds
+   */
+  tillDateUTCMillis?: number;
 }
 
 export interface IGetProcessStatisticsReply extends IProcessReply {


### PR DESCRIPTION
* Avoid timezone loss during serialization when transferring timeframe as Date object

Issue: EF-2627