### PR TITLE
Remove stabilityDays for renovate bot updates for itself

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -17,7 +17,7 @@ module.exports = {
     {
       matchPackageNames: ["renovatebot/github-action"],
       // Reduce stability days for renovate bot updates for itself as they update regularly and otherwise, it would never update itself
-      stabilityDays: 1,
+      stabilityDays: 0,
     },
     {
       matchPackageNames: ["node", "@types/node"],


### PR DESCRIPTION
* Otherwise renovate does not update itself as it does not reach stabilityDays because of recent updates