### PR TITLE
Explicitly type request to ReportGenerator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "processhub-sdk",
-  "version": "9.41.0-5",
+  "version": "9.41.0-6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "processhub-sdk",
-      "version": "9.41.0-5",
+      "version": "9.41.0-6",
       "license": "MIT",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "9.41.0-5",
+  "version": "9.41.0-6",
   "author": {
     "name": "ROXTRA",
     "email": "service@roxtra.com",

--- a/src/instance/legacyapi.test.ts
+++ b/src/instance/legacyapi.test.ts
@@ -1,0 +1,76 @@
+import { expect } from "chai";
+import { IGenerateReportRequest, IGenerateReportRequestSchema, RequestedInstanceReportType } from "./legacyapi";
+
+describe("sdk", function () {
+  describe("instance", function () {
+    describe("legacyapi", function () {
+      describe("IGenerateReportRequest", function () {
+        function validateIgenerateReportRequest(request: IGenerateReportRequest): void {
+          expect(IGenerateReportRequestSchema.validate(request).error).is.undefined;
+        }
+
+        it("passes validation for requests of all types of RequestedInstanceReportType", function () {
+          for (const reportType in RequestedInstanceReportType) {
+            if (isNaN(Number(reportType))) {
+              continue;
+            }
+            switch (Number(reportType)) {
+              case RequestedInstanceReportType.PROCESSES_REGULAR: {
+                const request: IGenerateReportRequest = {
+                  reportType: RequestedInstanceReportType.PROCESSES_REGULAR,
+                  draftId: "123",
+                  instanceIds: [],
+                  resultingFileType: "docx",
+                  moduleId: 1,
+                };
+                validateIgenerateReportRequest(request);
+                break;
+              }
+              case RequestedInstanceReportType.PROCESSES_STATISTICS: {
+                const request: IGenerateReportRequest = {
+                  reportType: RequestedInstanceReportType.PROCESSES_STATISTICS,
+                  draftId: "123",
+                  instanceIds: [],
+                  resultingFileType: "docx",
+                  moduleId: 1,
+                  statisticsChart: {
+                    fromDate: new Date(),
+                    toDate: new Date(),
+                    image: "",
+                    selection: "",
+                  },
+                };
+                validateIgenerateReportRequest(request);
+                break;
+              }
+              case RequestedInstanceReportType.RISKS: {
+                const request: IGenerateReportRequest = {
+                  reportType: RequestedInstanceReportType.RISKS,
+                  draftId: "123",
+                  instanceIds: [],
+                  resultingFileType: "docx",
+                  moduleId: 3,
+                };
+                validateIgenerateReportRequest(request);
+                break;
+              }
+              case RequestedInstanceReportType.GENERIC_MODULE: {
+                const request: IGenerateReportRequest = {
+                  reportType: RequestedInstanceReportType.GENERIC_MODULE,
+                  draftId: "123",
+                  instanceIds: [],
+                  resultingFileType: "docx",
+                  moduleId: 9,
+                };
+                validateIgenerateReportRequest(request);
+                break;
+              }
+              default:
+                expect.fail(`Missing test implementation for RequestedInstanceReportType ${String(reportType)}`);
+            }
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
* Introduce type property in IGenerateReportRequest request to distinguish between requested report types

Issue: EF-2213