### PR TITLE
Added enum for basic report generator structure 

### DIFF
--- a/src/workspace/legacyapi.ts
+++ b/src/workspace/legacyapi.ts
@@ -23,3 +23,14 @@ export interface IUpdateWorkspaceRolesRequest extends IBaseRequest {
 export interface IUpdateWorkspaceRolesReply extends IBaseReply {
   workspace?: IWorkspaceDetails;
 }
+
+export enum RequestedWorkspaceReportType {
+  /**
+   * Represents a regular workspace report request
+   */
+  WORKSPACE_REGULAR = 1,
+  /**
+   * Represents an workspace audit trail report request
+   */
+  AUDIT_TRAIL = 6,
+} 


### PR DESCRIPTION
Issue EF-3952 wants PDF export for audit trail of workspace. Analog to report of instance/process, i rather implement the basic report structure aswell so we have it easier in the future