### PR TITLE
Renamed API_DUPLICATE to more clearly reflect that the error is due t…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "processhub-sdk",
-  "version": "9.113.0-1",
+  "version": "9.113.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "processhub-sdk",
-      "version": "9.113.0-1",
+      "version": "9.113.0-2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git://github.com/roXtra/processhub-sdk.git"
   },
-  "version": "9.113.0-1",
+  "version": "9.113.0-2",
   "author": {
     "name": "ROXTRA",
     "email": "service@roxtra.com",

--- a/src/legacyapi/apiinterfaces.ts
+++ b/src/legacyapi/apiinterfaces.ts
@@ -10,7 +10,7 @@ export enum ApiResult {
   API_FORBIDDEN = 403, // User is signed in but has insufficient rights
   API_NOTFOUND = 404,
   API_REQUESTTIMEOUT = 408,
-  API_DUPLICATE = 409,
+  API_CONFLICT = 409,
   API_REQUEST_ENTITY_TOO_LARGE = 413,
   API_QUOTA_EXCEEDED = 429,
   API_NOTEMPTY = 423,


### PR DESCRIPTION
…o a concurrency error and better match the spec (https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict)

RM-108